### PR TITLE
Fix Error's

### DIFF
--- a/functions.inc.php
+++ b/functions.inc.php
@@ -241,7 +241,7 @@ function PMBP_print_footer()
             $ping_res = PMBP_is_connected();
             if ($ping_res) {
                 if (isset($CONF['sql_host_s'])) {
-                    $mode = $_SESSION['multi_user_mode'] ? 'm' : 's'+count($CONF['sql_host_s']) ? 'm' : 's';
+                    $mode = $_SESSION['multi_user_mode'] ? 'm' : ('s'+count($CONF['sql_host_s']) ? 'm' : 's');
                 }
                 @set_time_limit("5");
                 if (isset($PMBP_SYS_VAR['security_key'])) {

--- a/functions.inc.php
+++ b/functions.inc.php
@@ -1815,7 +1815,9 @@ function PMBP_getln($path, $close = false, $org_path = false)
 
         if ($close) {
             // remove the file handler
-            @gzclose($GLOBALS['lnFile']);
+            if (is_resource($GLOBALS['lnFile'])) {
+                @gzclose($GLOBALS['lnFile']);
+            }
             $GLOBALS['lnFile'] = null;
             return null;
         }


### PR DESCRIPTION
Fix: PHP Fatal error:  Unparenthesized `a ? b : c ? d : e` is not supported. Use either `(a ? b : c) ? d : e` or `a ? b : (c ? d : e)` in functions.inc.php on line 244

Fix: PHP Fatal error:  Uncaught TypeError: gzclose(): Argument #1 ($stream) must be of type resource, null given in functions.inc.php:1818\nStack trace:\n#0 functions.inc.php(1818): gzclose()\n#1 get_file.php(55): PMBP_getln()\n#2 {main}\n  thrown in functions.inc.php on line 1818, referer: http://phpmybackuppro/import.php